### PR TITLE
Added empty folder LIB/

### DIFF
--- a/LIB/README
+++ b/LIB/README
@@ -1,0 +1,1 @@
+This empty folder is assumed by the Makefile. After compilation you will find here the library.


### PR DESCRIPTION
At the moment you will get an error during compilation, because the Makefile assumes the empty folder LIB. After compilation you will find here the library. However, you can't add an empty folder to git. See the [Git FAQ](https://git.wiki.kernel.org/index.php/GitFaq#Can_I_add_empty_directories.3F).

In this Pull request I have added the folder a LIB and a short README file within this folder.
